### PR TITLE
Annotate lines with errors and display yaml parsing warning

### DIFF
--- a/go/lib/lib.go
+++ b/go/lib/lib.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -46,8 +47,9 @@ type TemplateData struct {
 }
 
 type GetYamlReturnValue struct {
-	Yaml string `json:"yaml"`
-	Err  string `json:"err"`
+	Yaml    string `json:"yaml"`
+	Err     string `json:"err"`
+	Warning string `json:"warning"`
 }
 
 func toJson(returnValue GetYamlReturnValue) string {
@@ -153,7 +155,18 @@ func GetYaml(templateYaml string, valuesYaml string) string {
 		})
 	}
 
+	outputYaml := output.String()
+
+	lintValues := ValuesObj{}
+	if err := yaml.Unmarshal([]byte(outputYaml), &lintValues); err != nil {
+		fmt.Printf("%e", err)
+		return toJson(GetYamlReturnValue{
+			Warning: err.Error(),
+			Yaml:    outputYaml,
+		})
+	}
+
 	return toJson(GetYamlReturnValue{
-		Yaml: output.String(),
+		Yaml: outputYaml,
 	})
 }

--- a/go/lib/lib_test.go
+++ b/go/lib/lib_test.go
@@ -13,60 +13,55 @@ func TestGetYaml(t *testing.T) {
 		{
 			templateYaml:        "",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"","err":""}`,
+			expectedReturnValue: `{"yaml":"","err":"","warning":""}`,
 		},
 
 		// Values
 		{
 			templateYaml:        "name: {{ .Values.foobar }}",
 			valuesYaml:          "foobar: hello",
-			expectedReturnValue: `{"yaml":"name: hello","err":""}`,
+			expectedReturnValue: `{"yaml":"name: hello","err":"","warning":""}`,
 		},
 		{
 			templateYaml:        "name: {{ .Values.foobar }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"name: \u003cno value\u003e","err":""}`,
+			expectedReturnValue: `{"yaml":"name: \u003cno value\u003e","err":"","warning":""}`,
 		},
 
 		// Built-in objects
 		{
-			templateYaml:        "name: {{ .Release | toYaml }}",
+			templateYaml:        "name: {{ .Release | toYaml | nindent 2 }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"name: IsInstall: false\nIsUpgrade: false\nName: example\nNamespace: example\nRevision: 1\nService: Helm","err":""}`,
+			expectedReturnValue: `{"yaml":"name: \n  IsInstall: false\n  IsUpgrade: false\n  Name: example\n  Namespace: example\n  Revision: 1\n  Service: Helm","err":"","warning":""}`,
 		},
 		{
-			templateYaml:        "name: {{ .Chart | toYaml }}",
+			templateYaml:        "name: {{ .Chart | toYaml | nindent 2 }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"name: Annotations: {}\nApiVersion: v2\nAppVersion: \"\"\nDependencies: []\nDeprecated: false\nDescription: example\nHome: \"\"\nIcon: \"\"\nKeywords: []\nKubeVersion: \"\"\nMaintainers: []\nName: example\nSources: []\nType: application\nVersion: 0.1.0","err":""}`,
+			expectedReturnValue: `{"yaml":"name: \n  Annotations: {}\n  ApiVersion: v2\n  AppVersion: \"\"\n  Dependencies: []\n  Deprecated: false\n  Description: example\n  Home: \"\"\n  Icon: \"\"\n  Keywords: []\n  KubeVersion: \"\"\n  Maintainers: []\n  Name: example\n  Sources: []\n  Type: application\n  Version: 0.1.0","err":"","warning":""}`,
 		},
 
 		// Template functions
 		{
 			templateYaml:        "name: {{ .Values.foobar | default \"fallback\" }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"name: fallback","err":""}`,
+			expectedReturnValue: `{"yaml":"name: fallback","err":"","warning":""}`,
 		},
 
 		// Helm built-in template functions
 		{
-			templateYaml:        "name: {{ .Values.foobar | toYaml }}",
-			valuesYaml:          "foobar: ['first', 'second']",
-			expectedReturnValue: `{"yaml":"name: - first\n- second","err":""}`,
-		},
-		{
 			templateYaml:        "name: {{ .Values.foobar | toYaml | nindent 2 }}",
 			valuesYaml:          "foobar:\n  first: 1\n  second: 2",
-			expectedReturnValue: `{"yaml":"name: \n  first: 1\n  second: 2","err":""}`,
+			expectedReturnValue: `{"yaml":"name: \n  first: 1\n  second: 2","err":"","warning":""}`,
 		},
 		{
 			templateYaml:        "name: {{ .Values.foobar | required }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"name: \u003cno value\u003e","err":""}`,
+			expectedReturnValue: `{"yaml":"name: \u003cno value\u003e","err":"","warning":""}`,
 		},
 		{
 			templateYaml:        "{{ fail \"reason\" }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"","err":""}`,
+			expectedReturnValue: `{"yaml":"","err":"","warning":""}`,
 		},
 		{
 			templateYaml: `
@@ -76,7 +71,7 @@ func TestGetYaml(t *testing.T) {
 				fromTemplate: {{ include "foobar.name" .Values.name -}}
 			`,
 			valuesYaml:          "name: '123456789'",
-			expectedReturnValue: `{"yaml":"fromTemplate: 12345","err":""}`,
+			expectedReturnValue: `{"yaml":"fromTemplate: 12345","err":"","warning":""}`,
 		},
 		{
 			templateYaml: `
@@ -86,24 +81,31 @@ func TestGetYaml(t *testing.T) {
 				fromTemplate: {{ include "foobar.name" .Values.name -}}
 			`,
 			valuesYaml:          "name: '123456789'",
-			expectedReturnValue: `{"yaml":"","err":"template: template:5:21: executing \"template\" at \u003cinclude \"foobar.name\" .Values.name\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: rendering template has a nested reference name: foobar.name"}`,
+			expectedReturnValue: `{"yaml":"","err":"template: template:5:21: executing \"template\" at \u003cinclude \"foobar.name\" .Values.name\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: template: template:3:10: executing \"foobar.name\" at \u003cinclude \"foobar.name\" .\u003e: error calling include: rendering template has a nested reference name: foobar.name","warning":""}`,
 		},
 
 		// Template formatting error
 		{
 			templateYaml:        "name: {{ .Values. }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"","err":"template: template:1: unexpected \u003c.\u003e in operand"}`,
+			expectedReturnValue: `{"yaml":"","err":"template: template:1: unexpected \u003c.\u003e in operand","warning":""}`,
 		},
 		{
 			templateYaml:        "\n\nname: {{ .Values. }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"","err":"template: template:3: unexpected \u003c.\u003e in operand"}`,
+			expectedReturnValue: `{"yaml":"","err":"template: template:3: unexpected \u003c.\u003e in operand","warning":""}`,
 		},
 		{
 			templateYaml:        "\nname: {{ .Values.foobar | what }}",
 			valuesYaml:          "",
-			expectedReturnValue: `{"yaml":"","err":"template: template:2: function \"what\" not defined"}`,
+			expectedReturnValue: `{"yaml":"","err":"template: template:2: function \"what\" not defined","warning":""}`,
+		},
+
+		// Warning about malformed yaml
+		{
+			templateYaml:        "first: truesecond:\n  third: true",
+			valuesYaml:          "",
+			expectedReturnValue: `{"yaml":"first: truesecond:\n  third: true","err":"","warning":"error converting YAML to JSON: yaml: mapping values are not allowed in this context"}`,
 		},
 	}
 

--- a/index.html
+++ b/index.html
@@ -138,6 +138,22 @@
         return err;
       };
 
+      const parseTemplateError = (err) => {
+        if (err.startsWith("template: ")) {
+          const match = err.match(/template:([0-9]+)(?::([0-9]+))?/);
+          if (match) {
+            let [, lineNum, characterNum] = match;
+            if (characterNum === undefined) {
+              return { lineNum: parseInt(lineNum) - 1 };
+            }
+            return {
+              lineNum: parseInt(lineNum) - 1,
+              characterNum: parseInt(characterNum),
+            };
+          }
+        }
+      };
+
       startButton.addEventListener("click", () => {
         startButton.disabled = true;
         startButton.textContent = "Loading…";
@@ -147,13 +163,37 @@
           .then((getYaml) => {
             overlay.style.display = "none";
 
+            const markers = new Set();
+
             const onChange = () => {
               const templateValue = templateCodeMirror.getValue();
               const valuesValue = valuesCodeMirror.getValue();
 
               const { yaml, err } = getYaml(templateValue, valuesValue);
 
+              for (const marker of markers.values()) {
+                marker.clear();
+                markers.delete(marker);
+              }
+
               if (err) {
+                const templateError = parseTemplateError(err);
+                if (templateError) {
+                  const { lineNum, characterNum } = templateError;
+                  const start =
+                    typeof characterNum === "undefined" ? 0 : characterNum;
+                  const end =
+                    typeof characterNum === "undefined"
+                      ? 1000
+                      : characterNum + 1;
+                  const marker = templateCodeMirror.markText(
+                    { line: lineNum, ch: start },
+                    { line: lineNum, ch: end },
+                    { className: "marker-error" }
+                  );
+                  markers.add(marker);
+                }
+
                 errorNotification.style.display = "block";
                 errorNotification.textContent = formatError(err);
               } else {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
             <a href="https://github.com/shipmight/helm-playground">GitHub</a>.
           </p>
         </div>
-        <div class="error" style="display: none"></div>
+        <div class="floating-error" style="display: none"></div>
+        <div class="floating-warning" style="display: none"></div>
       </div>
     </div>
     <script src="codemirror/codemirror.js"></script>
@@ -130,7 +131,8 @@
 
       const overlay = document.querySelector(".overlay");
       const startButton = document.querySelector(".start");
-      const errorNotification = document.querySelector(".error");
+      const errorNotification = document.querySelector(".floating-error");
+      const warningNotification = document.querySelector(".floating-warning");
 
       const formatError = (err) => {
         err = err.replace("template: ", "template.yaml - ");
@@ -169,12 +171,18 @@
               const templateValue = templateCodeMirror.getValue();
               const valuesValue = valuesCodeMirror.getValue();
 
-              const { yaml, err } = getYaml(templateValue, valuesValue);
+              const { yaml, err, warning } = getYaml(
+                templateValue,
+                valuesValue
+              );
 
               for (const marker of markers.values()) {
                 marker.clear();
                 markers.delete(marker);
               }
+
+              errorNotification.style.display = "none";
+              warningNotification.style.display = "none";
 
               if (err) {
                 const templateError = parseTemplateError(err);
@@ -197,8 +205,12 @@
                 errorNotification.style.display = "block";
                 errorNotification.textContent = formatError(err);
               } else {
-                errorNotification.style.display = "none";
                 outputCodeMirror.setValue(yaml);
+
+                if (warning) {
+                  warningNotification.style.display = "block";
+                  warningNotification.textContent = `Warning, the generated YAML may contain parsing errors. Converting it to JSON failed: ${warning}`;
+                }
               }
 
               updateHash(templateValue, valuesValue);

--- a/style.css
+++ b/style.css
@@ -41,6 +41,10 @@
   --error-color: #fef2f2;
   --error-border: #ef4444;
 
+  --warning-bg: #ca8a04;
+  --warning-color: #fefce8;
+  --warning-border: #ca8a04;
+
   --content-bg: #1e293b;
   --content-color: #e2e8f0;
 
@@ -229,7 +233,7 @@ body {
   opacity: 0.5;
 }
 
-.error {
+.floating-error {
   position: absolute;
   left: 16px;
   right: 16px;
@@ -238,6 +242,18 @@ body {
   background-color: var(--error-bg);
   color: var(--error-color);
   border-left: 2px solid var(--error-border);
+  z-index: var(--z-index-above-codemirror);
+}
+
+.floating-warning {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  padding: 16px;
+  background-color: var(--warning-bg);
+  color: var(--warning-color);
+  border-left: 2px solid var(--warning-border);
   z-index: var(--z-index-above-codemirror);
 }
 

--- a/style.css
+++ b/style.css
@@ -241,6 +241,12 @@ body {
   z-index: var(--z-index-above-codemirror);
 }
 
+.marker-error.marker-error {
+  background-color: var(--error-bg);
+  color: var(--error-color);
+  box-shadow: 0 2px 0 0 var(--error-border);
+}
+
 @media all and (max-width: 799px) {
   .content {
     flex-direction: column;


### PR DESCRIPTION
This PR…

### Adds annotations for lines with errors

Highlights line:

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/211543/174442711-49a20f2c-0fd7-423d-ba97-a38b0df71fa8.png">

Or specific character if available:

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/211543/174442752-a9491b83-5bbf-4c87-a07d-0273b3333c07.png">

### Shows a warning if the generated YAML output is malformed

I.e. issue #7

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/211543/174442648-257879bb-bce3-46fb-9080-3d3bb5448471.png">
