### PR TITLE
fix puppeteer not working on github actions

### DIFF
--- a/browser-test/run.js
+++ b/browser-test/run.js
@@ -32,7 +32,9 @@ async function run() {
   console.error(`[browser-test] server started at ${serverUrl}`);
 
   console.error("[browser-test] starting browser");
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
   const page = await browser.newPage();
   await page.goto(serverUrl);
   console.error("[browser-test] started browser");


### PR DESCRIPTION
Fixes this github pipeline errors:
```
yarn install v1.22.22
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 6.62s.
node browser-test/run.js
[browser-test] starting server
[browser-test] server started at http://127.0.0.1:8123
[browser-test] starting browser
[browser-test] ERROR  Error: Failed to launch the browser process!
[0124/090623.034195:FATAL:zygote_host_impl_linux.cc(117)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
#0 0x5594a4a5a029 base::debug::CollectStackTrace()
#1 0x5594a49c1623 base::debug::StackTrace::StackTrace()
#2 0x5594a49d48f0 logging::LogMessage::~LogMessage()
#3 0x5594a2ae540b content::ZygoteHostImpl::Init()
#4 0x5594a455bd56 content::ContentMainRunnerImpl::Initialize()
#5 0x5594a4559aa1 content::RunContentProcess()
#6 0x5594a455a45e content::ContentMain()
#7 0x5594a45b87ce headless::HeadlessBrowserMain()
#8 0x5594a45b84fd headless::HeadlessShellMain()
#9 0x5594a12ff133 ChromeMain
#10 0x7fcbb242a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#11 0x7fcbb242a28b __libc_start_main
#12 0x5594a12fef6a _start

Received signal 6
#0 0x5594a4a5a029 base::debug::CollectStackTrace()
#1 0x5594a49c1623 base::debug::StackTrace::StackTrace()
#2 0x5594a4a59b01 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7fcbb2445320 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4531f)
#4 0x7fcbb249eb1c pthread_kill
#5 0x7fcbb244526e gsignal
#6 0x7fcbb24288ff abort
#7 0x5594a4a58d95 base::debug::BreakDebuggerAsyncSafe()
#8 0x5594a49d4d1f logging::LogMessage::~LogMessage()
#9 0x5594a2ae540b content::ZygoteHostImpl::Init()
#10 0x5594a455bd56 content::ContentMainRunnerImpl::Initialize()
#11 0x5594a4559aa1 content::RunContentProcess()
#12 0x5594a455a45e content::ContentMain()
#13 0x5594a45b87ce headless::HeadlessBrowserMain()
#14 0x5594a45b84fd headless::HeadlessShellMain()
#15 0x5594a12ff133 ChromeMain
#16 0x7fcbb242a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#17 0x7fcbb242a28b __libc_start_main
#18 0x5594a12fef6a _start
  r8: 0000000000000000  r9: 0000000000000000 r10: 0000000000000008 r11: 0000000000000246
 r12: 0000000000000006 r13: 00007ffff31dc560 r14: 0000000000000016 r15: aaaaaaaaaaaaaaaa
  di: 0000000000000b2f  si: 0000000000000b2f  bp: 00007ffff31dc460  bx: 0000000000000b2f
  dx: 0000000000000006  ax: 0000000000000000  cx: 00007fcbb249eb1c  sp: 00007ffff31dc420
  ip: 00007fcbb249eb1c efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]


TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md

    at onClose (/home/runner/work/helm-playground/helm-playground/browser-test/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:229:20)
    at Interface.<anonymous> (/home/runner/work/helm-playground/helm-playground/browser-test/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:219:68)
    at Interface.emit (node:events:525:35)
    at Interface.close (node:readline:590:8)
    at Socket.onend (node:readline:280:10)
    at Socket.emit (node:events:525:35)
    at endReadableNT (node:internal/streams/readable:1358:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
make: *** [Makefile:14: browser-test] Error 1
Error: Process completed with exit code 2.
0s
```

via hint:

```
[0124/090623.034195:FATAL:zygote_host_impl_linux.cc(117)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

Used https://stackoverflow.com/questions/48147455/puppeteer-launch-with-no-sandbox-and-no-headless to understand how to disable sandbox properly.

required to make able to run pipelines again