### PR TITLE
Prevent infinite loop in tpl

### DIFF
--- a/go/main/main.go
+++ b/go/main/main.go
@@ -13,7 +13,7 @@ func jsFuncWrapper() js.Func {
 		}
 		templateYaml := args[0].String()
 		valuesYaml := args[1].String()
-		returnValue := lib.GetYaml(templateYaml, valuesYaml)
+		returnValue := lib.GetYaml(templateYaml, valuesYaml, lib.GetYamlConfig{MaxTplRuns: 100})
 		return returnValue
 	})
 }


### PR DESCRIPTION
Noticed after merging #16 that user is able to crash the tab by supplying a self-rendering template.

This PR adds a simple counter to prevent tpl causing an infinite loop.

FYI @nbragin4 